### PR TITLE
Demo App still used Bluetooth Engine vTwo

### DIFF
--- a/app/src/main/java/willi/boelke/service_discovery_demo/view/demoFragments/BluetoothDiscoveryFragment.java
+++ b/app/src/main/java/willi/boelke/service_discovery_demo/view/demoFragments/BluetoothDiscoveryFragment.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import willi.boelke.service_discovery_demo.R;
 import willi.boelke.service_discovery_demo.databinding.FragmentBluetoothDiscoverBinding;
 import willi.boelke.service_discovery_demo.view.listAdapters.ServiceListAdapter;
+import willi.boelke.services.serviceDiscovery.bluetoothServiceDiscovery.BluetoothServiceDiscoveryVOne;
 import willi.boelke.services.serviceDiscovery.bluetoothServiceDiscovery.BluetoothServiceDiscoveryVTwo;
 
 public class BluetoothDiscoveryFragment extends Fragment
@@ -93,7 +94,7 @@ public class BluetoothDiscoveryFragment extends Fragment
 
     private void onClickEventHandler(View view)
     {
-        if (!BluetoothServiceDiscoveryVTwo.getInstance().isRunning())
+        if (!BluetoothServiceDiscoveryVOne.getInstance().isRunning())
         {
             Toast.makeText(getContext(), "Missing permission or bluetooth not supported", Toast.LENGTH_LONG).show();
             return;


### PR DESCRIPTION
The BluetoothDiscovery demo fragment still was trying to use the version two of the service discovery.
This was for the moment replaced by version one and thus not initialzed / started.  